### PR TITLE
MULE-13545: Cleanup core API

### DIFF
--- a/src/main/java/org/mule/service/oauth/internal/DefaultAuthorizationCodeOAuthDancer.java
+++ b/src/main/java/org/mule/service/oauth/internal/DefaultAuthorizationCodeOAuthDancer.java
@@ -47,7 +47,7 @@ import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.lifecycle.Lifecycle;
 import org.mule.runtime.api.lock.LockFactory;
 import org.mule.runtime.api.metadata.MediaType;
-import org.mule.runtime.core.api.DefaultMuleException;
+import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.core.api.util.IOUtils;
 import org.mule.runtime.core.api.util.StringUtils;
 import org.mule.runtime.http.api.HttpConstants;

--- a/src/main/java/org/mule/service/oauth/internal/DefaultOAuthService.java
+++ b/src/main/java/org/mule/service/oauth/internal/DefaultOAuthService.java
@@ -8,7 +8,7 @@ package org.mule.service.oauth.internal;
 
 import org.mule.runtime.api.el.MuleExpressionLanguage;
 import org.mule.runtime.api.lock.LockFactory;
-import org.mule.runtime.core.api.scheduler.SchedulerService;
+import org.mule.runtime.api.scheduler.SchedulerService;
 import org.mule.runtime.http.api.HttpService;
 import org.mule.runtime.oauth.api.OAuthService;
 import org.mule.runtime.oauth.api.builder.OAuthAuthorizationCodeDancerBuilder;

--- a/src/main/java/org/mule/service/oauth/internal/builder/DefaultOAuthAuthorizationCodeDancerBuilder.java
+++ b/src/main/java/org/mule/service/oauth/internal/builder/DefaultOAuthAuthorizationCodeDancerBuilder.java
@@ -16,7 +16,7 @@ import org.mule.runtime.api.el.MuleExpressionLanguage;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.lock.LockFactory;
 import org.mule.runtime.api.tls.TlsContextFactory;
-import org.mule.runtime.core.api.scheduler.SchedulerService;
+import org.mule.runtime.api.scheduler.SchedulerService;
 import org.mule.runtime.http.api.HttpService;
 import org.mule.runtime.http.api.server.HttpServer;
 import org.mule.runtime.http.api.server.HttpServerConfiguration;

--- a/src/main/java/org/mule/service/oauth/provider/OAuthServiceProvider.java
+++ b/src/main/java/org/mule/service/oauth/provider/OAuthServiceProvider.java
@@ -10,7 +10,7 @@ import static java.util.Collections.singletonList;
 
 import org.mule.runtime.api.service.ServiceDefinition;
 import org.mule.runtime.api.service.ServiceProvider;
-import org.mule.runtime.core.api.scheduler.SchedulerService;
+import org.mule.runtime.api.scheduler.SchedulerService;
 import org.mule.runtime.http.api.HttpService;
 import org.mule.runtime.oauth.api.OAuthService;
 import org.mule.service.oauth.internal.DefaultOAuthService;

--- a/src/test/java/org/mule/test/oauth/internal/DancerConfigTestCase.java
+++ b/src/test/java/org/mule/test/oauth/internal/DancerConfigTestCase.java
@@ -38,7 +38,7 @@ import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.lock.LockFactory;
 import org.mule.runtime.api.util.MultiMap;
 import org.mule.runtime.core.api.registry.RegistrationException;
-import org.mule.runtime.core.api.scheduler.SchedulerService;
+import org.mule.runtime.api.scheduler.SchedulerService;
 import org.mule.runtime.http.api.HttpService;
 import org.mule.runtime.http.api.client.HttpClient;
 import org.mule.runtime.http.api.client.HttpClientFactory;

--- a/src/test/java/org/mule/test/oauth/internal/OAuthContextTestCase.java
+++ b/src/test/java/org/mule/test/oauth/internal/OAuthContextTestCase.java
@@ -19,7 +19,7 @@ import static org.mule.runtime.oauth.api.state.ResourceOwnerOAuthContext.DEFAULT
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.el.MuleExpressionLanguage;
 import org.mule.runtime.api.lock.LockFactory;
-import org.mule.runtime.core.api.scheduler.SchedulerService;
+import org.mule.runtime.api.scheduler.SchedulerService;
 import org.mule.runtime.http.api.HttpService;
 import org.mule.runtime.http.api.client.HttpClient;
 import org.mule.runtime.http.api.server.HttpServer;


### PR DESCRIPTION
_ Moving classes out of core's api package
_ When possible, classes where moved to internal
_ Moved to privileged when classes where required on compatibility
_ Moved to other module's API when needed on tests or it made sense
_ Deleted if not needed anymore
_ Some tests were ignored as they use an internal class and need refactoring