### PR TITLE
MULE-15539: OAuth: Provide option `encodeClientCredentialsInBody` in

### DIFF
--- a/src/main/java/org/mule/service/oauth/internal/builder/DefaultOAuthAuthorizationCodeDancerBuilder.java
+++ b/src/main/java/org/mule/service/oauth/internal/builder/DefaultOAuthAuthorizationCodeDancerBuilder.java
@@ -60,6 +60,7 @@ public class DefaultOAuthAuthorizationCodeDancerBuilder extends AbstractOAuthDan
                                                     Map<String, DefaultResourceOwnerOAuthContext> tokensStore,
                                                     HttpService httpService, MuleExpressionLanguage expressionEvaluator) {
     super(lockProvider, tokensStore, httpService, expressionEvaluator);
+    encodeClientCredentialsInBody = true;
   }
 
   @Override

--- a/src/test/java/org/mule/test/oauth2/internal/authorizationcode/AuthorizationCodeTokenTestCase.java
+++ b/src/test/java/org/mule/test/oauth2/internal/authorizationcode/AuthorizationCodeTokenTestCase.java
@@ -68,6 +68,7 @@ public class AuthorizationCodeTokenTestCase extends AbstractOAuthTestCase {
     builder.localCallback(httpServer, "/localCallback");
     builder.localAuthorizationUrlPath("/auth");
     builder.clientCredentials("Aladdin", "open sesame");
+    builder.encodeClientCredentialsInBody(false);
 
     AuthorizationCodeOAuthDancer minimalDancer = startDancer(builder);
     localCallbackCaptor.getValue().handleRequest(buildLocalCallbackRequestContext(), mock(HttpResponseReadyCallback.class));
@@ -92,7 +93,6 @@ public class AuthorizationCodeTokenTestCase extends AbstractOAuthTestCase {
     builder.localCallback(httpServer, "/localCallback");
     builder.localAuthorizationUrlPath("/auth");
     builder.clientCredentials("Aladdin", "open sesame");
-    builder.encodeClientCredentialsInBody(true);
 
     AuthorizationCodeOAuthDancer minimalDancer = startDancer(builder);
     localCallbackCaptor.getValue().handleRequest(buildLocalCallbackRequestContext(), mock(HttpResponseReadyCallback.class));
@@ -126,6 +126,7 @@ public class AuthorizationCodeTokenTestCase extends AbstractOAuthTestCase {
     builder.tokenUrl("http://host/token");
     builder.authorizationUrl("http://host/auth");
     builder.clientCredentials("Aladdin", "open sesame");
+    builder.encodeClientCredentialsInBody(false);
 
     AuthorizationCodeOAuthDancer minimalDancer = startDancer(builder);
     minimalDancer.refreshToken(null);
@@ -147,7 +148,6 @@ public class AuthorizationCodeTokenTestCase extends AbstractOAuthTestCase {
     builder.tokenUrl("http://host/token");
     builder.authorizationUrl("http://host/auth");
     builder.clientCredentials("Aladdin", "open sesame");
-    builder.encodeClientCredentialsInBody(true);
 
     AuthorizationCodeOAuthDancer minimalDancer = startDancer(builder);
     minimalDancer.refreshToken(null);


### PR DESCRIPTION
authCode
* Fix default behavior