### PR TITLE
[WIP] [PROJECTX-6173] Implement Mulesoft Authorization Code OAuth Dancer

### DIFF
--- a/src/main/java/org/mule/service/oauth/internal/authorizationcode/AbstractAuthorizationCodeOAuthDancer.java
+++ b/src/main/java/org/mule/service/oauth/internal/authorizationcode/AbstractAuthorizationCodeOAuthDancer.java
@@ -1,0 +1,435 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.service.oauth.internal.authorizationcode;
+
+import org.mule.runtime.api.el.BindingContext;
+import org.mule.runtime.api.el.MuleExpressionLanguage;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.lifecycle.InitialisationException;
+import org.mule.runtime.api.lifecycle.Lifecycle;
+import org.mule.runtime.api.lifecycle.Startable;
+import org.mule.runtime.api.lifecycle.Stoppable;
+import org.mule.runtime.api.lock.LockFactory;
+import org.mule.runtime.api.metadata.DataType;
+import org.mule.runtime.api.metadata.MediaType;
+import org.mule.runtime.api.metadata.TypedValue;
+import org.mule.runtime.api.util.MultiMap;
+import org.mule.runtime.core.api.util.IOUtils;
+import org.mule.runtime.core.api.util.StringUtils;
+import org.mule.runtime.http.api.client.HttpClient;
+import org.mule.runtime.http.api.client.HttpRequestOptions;
+import org.mule.runtime.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.runtime.http.api.domain.message.request.HttpRequest;
+import org.mule.runtime.http.api.domain.message.request.HttpRequestBuilder;
+import org.mule.runtime.http.api.server.async.HttpResponseReadyCallback;
+import org.mule.runtime.oauth.api.AuthorizationCodeOAuthDancer;
+import org.mule.runtime.oauth.api.builder.AuthorizationCodeListener;
+import org.mule.runtime.oauth.api.builder.ClientCredentialsLocation;
+import org.mule.runtime.oauth.api.exception.TokenNotFoundException;
+import org.mule.runtime.oauth.api.exception.TokenUrlResponseException;
+import org.mule.runtime.oauth.api.state.DefaultResourceOwnerOAuthContext;
+import org.mule.runtime.oauth.api.state.ResourceOwnerOAuthContext;
+import org.mule.service.oauth.internal.state.TokenResponse;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Function;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonMap;
+import static org.apache.commons.codec.binary.Base64.encodeBase64String;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.mule.runtime.api.metadata.DataType.STRING;
+import static org.mule.runtime.api.metadata.MediaType.ANY;
+import static org.mule.runtime.api.metadata.MediaType.parse;
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.BAD_REQUEST;
+import static org.mule.runtime.http.api.HttpConstants.Method.POST;
+import static org.mule.runtime.http.api.HttpHeaders.Names.AUTHORIZATION;
+import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_TYPE;
+import static org.mule.runtime.http.api.HttpHeaders.Values.APPLICATION_X_WWW_FORM_URLENCODED;
+import static org.mule.runtime.http.api.utils.HttpEncoderDecoderUtils.encodeString;
+import static org.mule.runtime.oauth.api.builder.ClientCredentialsLocation.QUERY_PARAMS;
+import static org.mule.runtime.oauth.api.state.ResourceOwnerOAuthContext.DEFAULT_RESOURCE_OWNER_ID;
+import static org.mule.service.oauth.internal.OAuthConstants.CLIENT_ID_PARAMETER;
+import static org.mule.service.oauth.internal.OAuthConstants.CLIENT_SECRET_PARAMETER;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Base implementations with behavior common to all grant-types.
+ *
+ * @since 1.0
+ */
+public abstract class AbstractAuthorizationCodeOAuthDancer implements AuthorizationCodeOAuthDancer, Startable, Stoppable, Lifecycle {
+
+  private static final Logger LOGGER = getLogger(AbstractAuthorizationCodeOAuthDancer.class);
+  private static final int TOKEN_REQUEST_TIMEOUT_MILLIS = 60000;
+
+  protected final String clientId;
+  protected final String clientSecret;
+  protected final String tokenUrl;
+  protected final Charset encoding;
+  protected final String scopes;
+  protected final ClientCredentialsLocation clientCredentialsLocation;
+
+  protected final String responseAccessTokenExpr;
+  protected final String responseRefreshTokenExpr;
+  protected final String responseExpiresInExpr;
+  protected final Map<String, String> customParametersExtractorsExprs;
+  protected final Function<String, String> resourceOwnerIdTransformer;
+  protected final List<AuthorizationCodeListener> listeners;
+
+  private final LockFactory lockProvider;
+  private final Map<String, DefaultResourceOwnerOAuthContext> tokensStore;
+  private final HttpClient httpClient;
+  private final MuleExpressionLanguage expressionEvaluator;
+
+  protected AbstractAuthorizationCodeOAuthDancer(String clientId, String clientSecret, String tokenUrl, Charset encoding, String scopes,
+                                                 ClientCredentialsLocation clientCredentialsLocation, String responseAccessTokenExpr,
+                                                 String responseRefreshTokenExpr, String responseExpiresInExpr,
+                                                 Map<String, String> customParametersExtractorsExprs,
+                                                 Function<String, String> resourceOwnerIdTransformer, LockFactory lockProvider,
+                                                 Map<String, DefaultResourceOwnerOAuthContext> tokensStore, HttpClient httpClient,
+                                                 MuleExpressionLanguage expressionEvaluator, List<AuthorizationCodeListener> listeners) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.tokenUrl = tokenUrl;
+    this.encoding = encoding;
+    this.scopes = scopes;
+    this.clientCredentialsLocation = clientCredentialsLocation;
+    this.responseAccessTokenExpr = responseAccessTokenExpr;
+    this.responseRefreshTokenExpr = responseRefreshTokenExpr;
+    this.responseExpiresInExpr = responseExpiresInExpr;
+    this.customParametersExtractorsExprs = customParametersExtractorsExprs;
+    this.resourceOwnerIdTransformer = resourceOwnerIdTransformer;
+
+    this.lockProvider = lockProvider;
+    this.tokensStore = tokensStore;
+    this.httpClient = httpClient;
+    this.expressionEvaluator = expressionEvaluator;
+
+    if (listeners != null) {
+      this.listeners = new CopyOnWriteArrayList<>(listeners);
+    } else {
+      this.listeners = new CopyOnWriteArrayList<>();
+    }
+  }
+
+  @Override
+  public void initialise() throws InitialisationException {
+
+  }
+
+  @Override
+  public void start() throws MuleException {
+    httpClient.start();
+  }
+
+  @Override
+  public void stop() throws MuleException {
+    httpClient.stop();
+  }
+
+  @Override
+  public void dispose() {
+
+  }
+
+  public void addListener(AuthorizationCodeListener listener) {
+    checkArgument(listener != null, "Cannot add a null listener");
+    listeners.add(listener);
+  }
+
+  public void removeListener(AuthorizationCodeListener listener) {
+    checkArgument(listener != null, "Cannot remove a null listener");
+    listeners.remove(listener);
+  }
+
+  public void invalidateContext(String resourceOwner) {
+    DefaultResourceOwnerOAuthContext context = (DefaultResourceOwnerOAuthContext) getContextForResourceOwner(resourceOwner);
+    context.getRefreshUserOAuthContextLock().lock();
+    try {
+      tokensStore.remove(resourceOwnerIdTransformer.apply(resourceOwner));
+    } finally {
+      context.getRefreshUserOAuthContextLock().unlock();
+    }
+  }
+
+  /**
+   * Retrieves the oauth context for a particular user. If there's no state for that user a new state is retrieve so never returns
+   * null.
+   *
+   * @param resourceOwnerId id of the user.
+   * @return oauth state
+   */
+  public ResourceOwnerOAuthContext getContextForResourceOwner(String resourceOwnerId) {
+    if (resourceOwnerId == null) {
+      resourceOwnerId = DEFAULT_RESOURCE_OWNER_ID;
+    }
+
+    final String transformedResourceOwnerId = resourceOwnerIdTransformer.apply(resourceOwnerId);
+
+    DefaultResourceOwnerOAuthContext resourceOwnerOAuthContext = null;
+    if (!tokensStore.containsKey(transformedResourceOwnerId)) {
+      final Lock lock = lockProvider.createLock(toString() + "-config-oauth-context");
+      lock.lock();
+      try {
+        if (!tokensStore.containsKey(transformedResourceOwnerId)) {
+          resourceOwnerOAuthContext =
+                  new DefaultResourceOwnerOAuthContext(createLockForResourceOwner(transformedResourceOwnerId), resourceOwnerId);
+          tokensStore.put(transformedResourceOwnerId, resourceOwnerOAuthContext);
+        }
+      } finally {
+        lock.unlock();
+      }
+    }
+    if (resourceOwnerOAuthContext == null) {
+      resourceOwnerOAuthContext = tokensStore.get(transformedResourceOwnerId);
+      resourceOwnerOAuthContext.setRefreshUserOAuthContextLock(createLockForResourceOwner(transformedResourceOwnerId));
+    }
+    return resourceOwnerOAuthContext;
+  }
+
+  /**
+   * Based on the value of {@code clientCredentialsLocation}, add the clientId and clientSecret values to the form or encode
+   * and return them.
+   *
+   * @param formData
+   */
+  protected String handleClientCredentials(final Map<String, String> formData) {
+    switch (clientCredentialsLocation) {
+      case BASIC_AUTH_HEADER:
+        return "Basic " + encodeBase64String(format("%s:%s", clientId, clientSecret).getBytes());
+      case BODY:
+        formData.put(CLIENT_ID_PARAMETER, clientId);
+        formData.put(CLIENT_SECRET_PARAMETER, clientSecret);
+    }
+    return null;
+  }
+
+  protected CompletableFuture<TokenResponse> invokeTokenUrl(String tokenUrl,
+                                                            Map<String, String> tokenRequestFormToSend,
+                                                            MultiMap<String, String> queryParams,
+                                                            String authorization,
+                                                            boolean retrieveRefreshToken,
+                                                            Charset encoding) {
+    final HttpRequestBuilder requestBuilder = HttpRequest.builder()
+        .uri(tokenUrl).method(POST.name())
+        .entity(new ByteArrayHttpEntity(encodeString(tokenRequestFormToSend, encoding).getBytes()))
+        .addHeader(CONTENT_TYPE, APPLICATION_X_WWW_FORM_URLENCODED.toRfcString())
+        .queryParams(queryParams);
+
+    if (authorization != null) {
+      requestBuilder.addHeader(AUTHORIZATION, authorization);
+    } else if (QUERY_PARAMS.equals(clientCredentialsLocation)) {
+      requestBuilder.addQueryParam(CLIENT_ID_PARAMETER, clientId);
+      requestBuilder.addQueryParam(CLIENT_SECRET_PARAMETER, clientSecret);
+    }
+
+    return httpClient.sendAsync(requestBuilder.build(), HttpRequestOptions.builder()
+        .responseTimeout(TOKEN_REQUEST_TIMEOUT_MILLIS)
+        .build())
+        .exceptionally(t -> {
+          return withContextClassLoader(AbstractAuthorizationCodeOAuthDancer.class.getClassLoader(), () -> {
+            if (t instanceof IOException) {
+              throw new CompletionException(new TokenUrlResponseException(tokenUrl, (IOException) t));
+            } else {
+              throw new CompletionException(t);
+            }
+          });
+        })
+        .thenApply(response -> {
+          return withContextClassLoader(AbstractAuthorizationCodeOAuthDancer.class.getClassLoader(), () -> {
+            String contentType = response.getHeaderValue(CONTENT_TYPE);
+            MediaType responseContentType = contentType != null ? parse(contentType) : ANY;
+
+            String body = IOUtils.toString(response.getEntity().getContent());
+
+            if (response.getStatusCode() >= BAD_REQUEST.getStatusCode()) {
+              try {
+                throw new CompletionException(new TokenUrlResponseException(tokenUrl, response, body));
+              } catch (IOException e) {
+                throw new CompletionException(new TokenUrlResponseException(tokenUrl, e));
+              }
+            }
+
+            MultiMap<String, String> headers = response.getHeaders();
+
+            TokenResponse tokenResponse = new TokenResponse();
+            tokenResponse
+                .setAccessToken(resolveExpression(responseAccessTokenExpr, body, headers, responseContentType));
+            if (tokenResponse.getAccessToken() == null) {
+              throw new CompletionException(new TokenNotFoundException(tokenUrl, response, body));
+            }
+            if (retrieveRefreshToken) {
+              tokenResponse
+                  .setRefreshToken(resolveExpression(responseRefreshTokenExpr, body, headers, responseContentType));
+            }
+            tokenResponse.setExpiresIn(resolveExpression(responseExpiresInExpr, body, headers, responseContentType));
+
+            if (customParametersExtractorsExprs != null && !customParametersExtractorsExprs.isEmpty()) {
+              Map<String, Object> customParams = new HashMap<>();
+              for (Entry<String, String> customParamExpr : customParametersExtractorsExprs.entrySet()) {
+                customParams.put(customParamExpr.getKey(),
+                                 resolveExpression(customParamExpr.getValue(), body, headers, responseContentType));
+              }
+              tokenResponse.setCustomResponseParameters(customParams);
+            }
+
+            return tokenResponse;
+          });
+        });
+  }
+
+  protected <T> T resolveExpression(String expr, Object body, MultiMap<String, String> headers,
+                                    MediaType responseContentType) {
+    if (expr == null) {
+      return null;
+    } else if (!expressionEvaluator.isExpression(expr)) {
+      return (T) expr;
+    } else {
+      BindingContext resultContext = BindingContext.builder()
+          .addBinding("payload",
+                      new TypedValue(body, DataType.builder().fromObject(body)
+                          .mediaType(responseContentType).build()))
+
+          .addBinding("attributes", new TypedValue(singletonMap("headers", headers.toImmutableMultiMap()),
+                                                   DataType.fromType(Map.class)))
+          .addBinding("dataType",
+                      new TypedValue(DataType.builder().fromObject(body).mediaType(responseContentType)
+                          .build(), DataType.fromType(DataType.class)))
+          .build();
+
+      return (T) expressionEvaluator.evaluate(expr, STRING, resultContext).getValue();
+    }
+  }
+
+  protected <T> T resolveExpression(String expr, Object body, MultiMap<String, String> headers,
+                                    MultiMap<String, String> queryParams, MediaType responseContentType) {
+    if (expr == null) {
+      return null;
+    } else if (!expressionEvaluator.isExpression(expr)) {
+      return (T) expr;
+    } else {
+      Map<Object, Object> attributes = new HashMap<>(2);
+      attributes.put("headers", headers.toImmutableMultiMap());
+      attributes.put("queryParams", queryParams.toImmutableMultiMap());
+
+      BindingContext resultContext = BindingContext.builder()
+          .addBinding("payload",
+                      new TypedValue(body, DataType.builder().fromObject(body)
+                          .mediaType(responseContentType).build()))
+
+          .addBinding("attributes", new TypedValue(attributes, DataType.fromType(Map.class)))
+          .addBinding("dataType",
+                      new TypedValue(DataType.builder().fromObject(body).mediaType(responseContentType)
+                          .build(), DataType.fromType(DataType.class)))
+          .build();
+
+      return (T) expressionEvaluator.evaluate(expr, DataType.STRING, resultContext).getValue();
+    }
+  }
+
+
+  private Lock createLockForResourceOwner(String resourceOwnerId) {
+    String lockId = toString() + (isBlank(resourceOwnerId) ? "" : "-" + resourceOwnerId);
+    return lockProvider.createLock(lockId);
+  }
+
+  /**
+   * Updates the resource owner oauth context information
+   *
+   * @param resourceOwnerOAuthContext
+   */
+  protected void updateResourceOwnerOAuthContext(DefaultResourceOwnerOAuthContext resourceOwnerOAuthContext) {
+    final Lock resourceOwnerContextLock = resourceOwnerOAuthContext.getRefreshUserOAuthContextLock();
+    resourceOwnerContextLock.lock();
+    try {
+      tokensStore.put(resourceOwnerIdTransformer.apply(resourceOwnerOAuthContext.getResourceOwnerId()),
+                      resourceOwnerOAuthContext);
+    } finally {
+      resourceOwnerContextLock.unlock();
+    }
+  }
+
+  protected void updateResourceOwnerState(DefaultResourceOwnerOAuthContext resourceOwnerOAuthContext, String newState,
+                                          TokenResponse tokenResponse) {
+    resourceOwnerOAuthContext.setAccessToken(tokenResponse.getAccessToken());
+    if (tokenResponse.getRefreshToken() != null) {
+      resourceOwnerOAuthContext.setRefreshToken(tokenResponse.getRefreshToken());
+    }
+    resourceOwnerOAuthContext.setExpiresIn(tokenResponse.getExpiresIn());
+
+    // State may be null because there's no state or because this was called after refresh token.
+    if (newState != null) {
+      resourceOwnerOAuthContext.setState(newState);
+    }
+
+    final Map<String, Object> customResponseParameters = tokenResponse.getCustomResponseParameters();
+    for (String paramName : customResponseParameters.keySet()) {
+      final Object paramValue = customResponseParameters.get(paramName);
+      if (paramValue != null) {
+        resourceOwnerOAuthContext.getTokenResponseParameters().put(paramName, paramValue);
+      }
+    }
+
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("New OAuth State for resourceOwnerId %s is: accessToken(%s), refreshToken(%s), expiresIn(%s), state(%s)",
+              resourceOwnerOAuthContext.getResourceOwnerId(), resourceOwnerOAuthContext.getAccessToken(),
+              StringUtils.isBlank(resourceOwnerOAuthContext.getRefreshToken()) ? "Not issued"
+                      : resourceOwnerOAuthContext.getRefreshToken(),
+              resourceOwnerOAuthContext.getExpiresIn(), resourceOwnerOAuthContext.getState());
+    }
+  }
+
+  // TODO: remove this method from the interface
+  public void handleLocalAuthorizationRequest(HttpRequest request, HttpResponseReadyCallback responseCallback) {
+
+  }
+
+  // TODO: move these to another file
+
+  protected void logTrace(String message) {
+    if (LOGGER.isTraceEnabled()) {
+      LOGGER.trace(message);
+    }
+  }
+
+  protected void logDebug(String message) {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.trace(message);
+    }
+  }
+
+  protected void logInfo(String message) {
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.trace(message);
+    }
+  }
+
+  protected void logWarn(String message) {
+    if (LOGGER.isWarnEnabled()) {
+      LOGGER.trace(message);
+    }
+  }
+
+  protected void logError(String message) {
+    if (LOGGER.isErrorEnabled()) {
+      LOGGER.trace(message);
+    }
+  }
+}

--- a/src/main/java/org/mule/service/oauth/internal/authorizationcode/MuleSoftAuthorizationCodeOAuthDancer.java
+++ b/src/main/java/org/mule/service/oauth/internal/authorizationcode/MuleSoftAuthorizationCodeOAuthDancer.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.service.oauth.internal.authorizationcode;
+
+import org.mule.runtime.api.el.MuleExpressionLanguage;
+import org.mule.runtime.api.exception.DefaultMuleException;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.runtime.api.lifecycle.InitialisationException;
+import org.mule.runtime.api.lifecycle.Lifecycle;
+import org.mule.runtime.api.lock.LockFactory;
+import org.mule.runtime.api.metadata.MediaType;
+import org.mule.runtime.api.util.MultiMap;
+import org.mule.runtime.core.api.util.IOUtils;
+import org.mule.runtime.core.api.util.StringUtils;
+import org.mule.runtime.http.api.HttpConstants.HttpStatus;
+import org.mule.runtime.http.api.HttpConstants.Method;
+import org.mule.runtime.http.api.client.HttpClient;
+import org.mule.runtime.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.runtime.http.api.domain.entity.EmptyHttpEntity;
+import org.mule.runtime.http.api.domain.message.request.HttpRequest;
+import org.mule.runtime.http.api.domain.message.response.HttpResponse;
+import org.mule.runtime.http.api.domain.message.response.HttpResponseBuilder;
+import org.mule.runtime.http.api.domain.request.HttpRequestContext;
+import org.mule.runtime.http.api.server.HttpServer;
+import org.mule.runtime.http.api.server.RequestHandler;
+import org.mule.runtime.http.api.server.RequestHandlerManager;
+import org.mule.runtime.http.api.server.async.HttpResponseReadyCallback;
+import org.mule.runtime.http.api.server.async.ResponseStatusCallback;
+import org.mule.runtime.oauth.api.AuthorizationCodeOAuthDancer;
+import org.mule.runtime.oauth.api.AuthorizationCodeRequest;
+import org.mule.runtime.oauth.api.builder.AuthorizationCodeDanceCallbackContext;
+import org.mule.runtime.oauth.api.builder.AuthorizationCodeListener;
+import org.mule.runtime.oauth.api.builder.ClientCredentialsLocation;
+import org.mule.runtime.oauth.api.exception.RequestAuthenticationException;
+import org.mule.runtime.oauth.api.exception.TokenNotFoundException;
+import org.mule.runtime.oauth.api.exception.TokenUrlResponseException;
+import org.mule.runtime.oauth.api.state.DefaultResourceOwnerOAuthContext;
+import org.mule.runtime.oauth.api.state.ResourceOwnerOAuthContext;
+import org.mule.service.oauth.internal.state.StateDecoder;
+import org.mule.service.oauth.internal.state.StateEncoder;
+import org.mule.service.oauth.internal.state.TokenResponse;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.Lock;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
+import static java.lang.Thread.currentThread;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singleton;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+import static org.mule.runtime.api.metadata.MediaType.ANY;
+import static org.mule.runtime.api.metadata.MediaType.parse;
+import static org.mule.runtime.api.util.MultiMap.emptyMultiMap;
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
+import static org.mule.runtime.core.api.util.StringUtils.isBlank;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.*;
+import static org.mule.runtime.http.api.HttpConstants.Method.GET;
+import static org.mule.runtime.http.api.HttpHeaders.Names.*;
+import static org.mule.runtime.http.api.utils.HttpEncoderDecoderUtils.appendQueryParam;
+import static org.mule.runtime.oauth.api.OAuthAuthorizationStatusCode.*;
+import static org.mule.runtime.oauth.api.state.ResourceOwnerOAuthContext.DEFAULT_RESOURCE_OWNER_ID;
+import static org.mule.service.oauth.internal.OAuthConstants.*;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Provides access token and refresh token from an external service, which performs the OAuth2 dance on our behalf.
+ *
+ * @since 1.0
+ */
+public class MuleSoftAuthorizationCodeOAuthDancer extends AbstractAuthorizationCodeOAuthDancer {
+
+  private static final Map<String, CompletableFuture<Void>> activeRefreshFutures = new ConcurrentHashMap<>();
+
+  public MuleSoftAuthorizationCodeOAuthDancer(String clientId, String clientSecret,
+                                              String tokenUrl, String scopes, ClientCredentialsLocation clientCredentialsLocation,
+                                              Charset encoding, String responseAccessTokenExpr, String responseRefreshTokenExpr,
+                                              String responseExpiresInExpr, Map<String, String> customParametersExtractorsExprs, Function<String, String> resourceOwnerIdTransformer,
+                                              LockFactory lockProvider, Map<String, DefaultResourceOwnerOAuthContext> tokensStore, HttpClient httpClient, MuleExpressionLanguage expressionEvaluator, List<AuthorizationCodeListener> listeners) {
+
+    super(clientId, clientSecret, tokenUrl, encoding, scopes, clientCredentialsLocation, responseAccessTokenExpr,
+            responseRefreshTokenExpr,
+            responseExpiresInExpr, customParametersExtractorsExprs, resourceOwnerIdTransformer, lockProvider, tokensStore,
+            httpClient, expressionEvaluator, listeners);
+  }
+
+  @Override
+  public CompletableFuture<String> accessToken(String resourceOwnerId) throws RequestAuthenticationException {
+    this.logDebug("Executing access token for user " + resourceOwnerId);
+
+    final String accessToken = this.getContextForResourceOwner(resourceOwnerId).getAccessToken();
+
+    if (accessToken == null) {
+      this.logDebug("Access token not found in the ObjectStore. Starting request to obtain the token");
+      return this.requestAccessTokenToMulesoftService(resourceOwnerId, null)
+              .thenApply(result ->  this.getContextForResourceOwner(resourceOwnerId).getAccessToken());
+    }
+
+
+    // TODO MULE-11858 proactively refresh if the token has already expired based on its 'expiresIn' parameter
+    return completedFuture(accessToken);
+  }
+
+  @Override
+  public CompletableFuture<Void> refreshToken(String resourceOwnerId) {
+    this.logDebug("Executing refresh token for resourceOwnerId " + resourceOwnerId);
+    return this.refreshToken(resourceOwnerId, false);
+  }
+
+  @Override
+  public CompletableFuture<Void> refreshToken(String resourceOwnerId, boolean useQueryParameters) {
+    this.logDebug("Executing refresh token for resourceOwnerId " + resourceOwnerId);
+
+    final String accessToken = this.getContextForResourceOwner(resourceOwnerId).getAccessToken();
+    return this.requestAccessTokenToMulesoftService(resourceOwnerId, accessToken);
+  }
+
+  private CompletableFuture<Void> requestAccessTokenToMulesoftService(String resourceOwner, String accessToken) {
+    final DefaultResourceOwnerOAuthContext resourceOwnerOAuthContext = (DefaultResourceOwnerOAuthContext) getContextForResourceOwner(resourceOwner);
+    String nullSafeResourceOwner = "" + resourceOwner;
+    CompletableFuture<Void> activeRefreshFuture = activeRefreshFutures.get(nullSafeResourceOwner);
+
+    // Return the active future if present
+    if (activeRefreshFuture != null) {
+      return activeRefreshFuture;
+    }
+
+    Lock lock = resourceOwnerOAuthContext.getRefreshUserOAuthContextLock();
+    final boolean lockWasAcquired = lock.tryLock();
+
+    if (lockWasAcquired) {
+      try {
+        CompletableFuture<Void> refreshFuture = this.getCoreServicesAccessToken()
+          .thenAccept(coreServicesAccessToken -> {
+
+            // Define body to send to the request
+            final MultiMap<String, String> queryParams = emptyMultiMap();
+            final MultiMap<String, String> formData = new MultiMap<>();
+            formData.put(GRANT_TYPE_PARAMETER, GRANT_TYPE_AUTHENTICATION_CODE);
+            formData.put(ACCESS_TOKEN_PARAMETER, accessToken);
+
+            // Create authorization header to authorize request to the tokenUrl
+            String authorization = "Bearer " + coreServicesAccessToken;
+
+            this.invokeTokenUrl(tokenUrl, formData, queryParams, authorization, true, encoding)
+              .thenAccept(tokenResponse -> {
+                lock.lock();
+                try {
+                  withContextClassLoader(MuleSoftAuthorizationCodeOAuthDancer.class.getClassLoader(), () -> {
+                    this.logDebug("Update OAuth Context for resourceOwnerId " + resourceOwnerOAuthContext.getResourceOwnerId());
+                    this.updateResourceOwnerState(resourceOwnerOAuthContext, null, tokenResponse);
+                    this.updateResourceOwnerOAuthContext(resourceOwnerOAuthContext);
+                    this.listeners.forEach(l -> l.onTokenRefreshed(resourceOwnerOAuthContext));
+                  });
+                } finally {
+                  lock.unlock();
+                }
+              });
+          });
+
+        activeRefreshFutures.put(nullSafeResourceOwner, refreshFuture);
+        refreshFuture.thenRun(() -> activeRefreshFutures.remove(nullSafeResourceOwner, refreshFuture));
+        return refreshFuture;
+      } finally {
+        lock.unlock();
+      }
+    } else {
+      lock.lock();
+      try {
+        return activeRefreshFutures.get(nullSafeResourceOwner);
+      } finally {
+        lock.unlock();
+      }
+    }
+  }
+
+  private CompletableFuture<String> getCoreServicesAccessToken() {
+    this.logDebug("Getting Core Services access token");
+
+    String clientId = System.getProperty("objectstore.client.clientId");
+    String clientSecret = System.getProperty("objectstore.client.clientSecret");
+
+    // TODO: Get CS API somehow
+    // TODO: Add token caching
+    // TODO: Check token expiration, if possible
+    return completedFuture("core-services-access-token");
+  }
+}

--- a/src/main/java/org/mule/service/oauth/internal/builder/AuthorizationCodeOAuthDancerDelegate.java
+++ b/src/main/java/org/mule/service/oauth/internal/builder/AuthorizationCodeOAuthDancerDelegate.java
@@ -1,0 +1,130 @@
+package org.mule.service.oauth.internal.builder;
+
+import org.mule.runtime.api.el.MuleExpressionLanguage;
+import org.mule.runtime.api.lock.LockFactory;
+import org.mule.runtime.http.api.client.HttpClient;
+import org.mule.runtime.http.api.domain.message.request.HttpRequest;
+import org.mule.runtime.http.api.server.HttpServer;
+import org.mule.runtime.http.api.server.async.HttpResponseReadyCallback;
+import org.mule.runtime.oauth.api.AuthorizationCodeOAuthDancer;
+import org.mule.runtime.oauth.api.AuthorizationCodeRequest;
+import org.mule.runtime.oauth.api.builder.AuthorizationCodeDanceCallbackContext;
+import org.mule.runtime.oauth.api.builder.AuthorizationCodeListener;
+import org.mule.runtime.oauth.api.builder.ClientCredentialsLocation;
+import org.mule.runtime.oauth.api.exception.RequestAuthenticationException;
+import org.mule.runtime.oauth.api.state.DefaultResourceOwnerOAuthContext;
+import org.mule.runtime.oauth.api.state.ResourceOwnerOAuthContext;
+import org.mule.service.oauth.internal.authorizationcode.DefaultAuthorizationCodeOAuthDancer;
+import org.mule.service.oauth.internal.authorizationcode.MuleSoftAuthorizationCodeOAuthDancer;
+
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class AuthorizationCodeOAuthDancerDelegate implements AuthorizationCodeOAuthDancer {
+
+    private AuthorizationCodeOAuthDancer defaultAuthorizationCodeOAuthDancer;
+    private AuthorizationCodeOAuthDancer mulesoftAuthorizationCodeOAuthDancer;
+    private final String resourceOwnerIdPrefix = "MULESOFT-";
+
+    public AuthorizationCodeOAuthDancerDelegate(Optional<HttpServer> httpServer, String clientId, String clientSecret,
+                                                String tokenUrl, String scopes, ClientCredentialsLocation clientCredentialsLocation,
+                                                String externalCallbackUrl, Charset encoding,
+                                                String localCallbackUrlPath, String localAuthorizationUrlPath,
+                                                String localAuthorizationUrlResourceOwnerId, String state, String authorizationUrl,
+                                                String responseAccessTokenExpr, String responseRefreshTokenExpr,
+                                                String responseExpiresInExpr, Supplier<Map<String, String>> customParameters,
+                                                Map<String, String> customParametersExtractorsExprs,
+                                                Function<String, String> resourceOwnerIdTransformer,
+                                                LockFactory lockProvider, Map<String, DefaultResourceOwnerOAuthContext> tokensStore,
+                                                HttpClient httpClient, MuleExpressionLanguage expressionEvaluator,
+                                                Function<AuthorizationCodeRequest, AuthorizationCodeDanceCallbackContext> beforeDanceCallback,
+                                                BiConsumer<AuthorizationCodeDanceCallbackContext, ResourceOwnerOAuthContext> afterDanceCallback,
+                                                List<AuthorizationCodeListener> listeners) {
+
+        this.defaultAuthorizationCodeOAuthDancer = new DefaultAuthorizationCodeOAuthDancer(httpServer, clientId, clientSecret,
+                tokenUrl, scopes, clientCredentialsLocation, externalCallbackUrl, encoding,
+                localCallbackUrlPath, localAuthorizationUrlPath,
+                localAuthorizationUrlResourceOwnerId, state,
+                authorizationUrl, responseAccessTokenExpr, responseRefreshTokenExpr,
+                responseExpiresInExpr, customParameters, customParametersExtractorsExprs,
+                resourceOwnerIdTransformer, lockProvider, tokensStore,
+                httpClient, expressionEvaluator, beforeDanceCallback,
+                afterDanceCallback, listeners);
+
+        this.mulesoftAuthorizationCodeOAuthDancer = new MuleSoftAuthorizationCodeOAuthDancer(clientId, clientSecret,
+                tokenUrl, scopes, clientCredentialsLocation, encoding,
+                responseAccessTokenExpr, responseRefreshTokenExpr,
+                responseExpiresInExpr, customParametersExtractorsExprs,
+                resourceOwnerIdTransformer, lockProvider, tokensStore,
+                httpClient, expressionEvaluator, listeners);
+    }
+
+    @Override
+    public CompletableFuture<String> accessToken(String resourceOwnerId) throws RequestAuthenticationException {
+        if (resourceOwnerId.startsWith(resourceOwnerIdPrefix)) {
+            return this.mulesoftAuthorizationCodeOAuthDancer.accessToken(resourceOwnerId);
+        }
+
+        return this.defaultAuthorizationCodeOAuthDancer.accessToken(resourceOwnerId);
+    }
+
+    @Override
+    public CompletableFuture<Void> refreshToken(String resourceOwnerId) {
+        if (resourceOwnerId.startsWith(resourceOwnerIdPrefix)) {
+            return this.mulesoftAuthorizationCodeOAuthDancer.refreshToken(resourceOwnerId);
+        }
+
+        return this.defaultAuthorizationCodeOAuthDancer.refreshToken(resourceOwnerId);
+    }
+
+    @Override
+    public CompletableFuture<Void> refreshToken(String resourceOwnerId, boolean useQueryParameters) {
+        if (resourceOwnerId.startsWith(resourceOwnerIdPrefix)) {
+            return this.mulesoftAuthorizationCodeOAuthDancer.refreshToken(resourceOwnerId, useQueryParameters);
+        }
+
+        return this.defaultAuthorizationCodeOAuthDancer.refreshToken(resourceOwnerId, useQueryParameters);
+    }
+
+    @Override
+    public void invalidateContext(String resourceOwnerId) {
+        if (resourceOwnerId.startsWith(resourceOwnerIdPrefix)) {
+            this.mulesoftAuthorizationCodeOAuthDancer.invalidateContext(resourceOwnerId);
+            return;
+        }
+
+        this.defaultAuthorizationCodeOAuthDancer.invalidateContext(resourceOwnerId);
+    }
+
+    @Override
+    public ResourceOwnerOAuthContext getContextForResourceOwner(String resourceOwnerId) {
+        if (resourceOwnerId.startsWith(resourceOwnerIdPrefix)) {
+            return this.mulesoftAuthorizationCodeOAuthDancer.getContextForResourceOwner(resourceOwnerId);
+        }
+
+        return this.defaultAuthorizationCodeOAuthDancer.getContextForResourceOwner(resourceOwnerId);
+    }
+
+    // TODO: we should find a way to decide which one to use for these three methods
+
+    @Override
+    public void handleLocalAuthorizationRequest(HttpRequest request, HttpResponseReadyCallback responseCallback) {
+        this.defaultAuthorizationCodeOAuthDancer.handleLocalAuthorizationRequest(request, responseCallback);
+    }
+
+    @Override
+    public void addListener(AuthorizationCodeListener listener) {
+        this.defaultAuthorizationCodeOAuthDancer.addListener(listener);
+    }
+
+    @Override
+    public void removeListener(AuthorizationCodeListener listener) {
+        this.defaultAuthorizationCodeOAuthDancer.removeListener(listener);
+    }
+}

--- a/src/main/java/org/mule/service/oauth/internal/builder/DefaultOAuthAuthorizationCodeDancerBuilder.java
+++ b/src/main/java/org/mule/service/oauth/internal/builder/DefaultOAuthAuthorizationCodeDancerBuilder.java
@@ -29,7 +29,6 @@ import org.mule.runtime.oauth.api.builder.AuthorizationCodeListener;
 import org.mule.runtime.oauth.api.builder.OAuthAuthorizationCodeDancerBuilder;
 import org.mule.runtime.oauth.api.state.DefaultResourceOwnerOAuthContext;
 import org.mule.runtime.oauth.api.state.ResourceOwnerOAuthContext;
-import org.mule.service.oauth.internal.DefaultAuthorizationCodeOAuthDancer;
 
 import java.net.URL;
 import java.util.LinkedList;
@@ -185,11 +184,10 @@ public class DefaultOAuthAuthorizationCodeDancerBuilder extends AbstractOAuthDan
     checkArgument(isNotBlank(clientId), "clientId cannot be blank");
     checkArgument(isNotBlank(clientSecret), "clientSecret cannot be blank");
     checkArgument(isNotBlank(tokenUrl), "tokenUrl cannot be blank");
-    checkArgument(isNotBlank(authorizationUrl), "authorizationUrl cannot be blank");
 
     Optional<HttpServer> httpServer = localCallbackServerFactory != null ? of(localCallbackServerFactory.get()) : empty();
 
-    return new DefaultAuthorizationCodeOAuthDancer(httpServer, clientId, clientSecret,
+    return new AuthorizationCodeOAuthDancerDelegate(httpServer, clientId, clientSecret,
                                                    tokenUrl, scopes, clientCredentialsLocation, externalCallbackUrl, encoding,
                                                    localCallbackUrlPath, localAuthorizationUrlPath,
                                                    localAuthorizationUrlResourceOwnerId, state,
@@ -199,5 +197,4 @@ public class DefaultOAuthAuthorizationCodeDancerBuilder extends AbstractOAuthDan
                                                    httpClientFactory.get(), expressionEvaluator, beforeDanceCallback,
                                                    afterDanceCallback, listeners);
   }
-
 }

--- a/src/main/java/org/mule/service/oauth/internal/builder/DefaultOAuthClientCredentialsDancerBuilder.java
+++ b/src/main/java/org/mule/service/oauth/internal/builder/DefaultOAuthClientCredentialsDancerBuilder.java
@@ -15,7 +15,7 @@ import org.mule.runtime.http.api.HttpService;
 import org.mule.runtime.oauth.api.ClientCredentialsOAuthDancer;
 import org.mule.runtime.oauth.api.builder.OAuthClientCredentialsDancerBuilder;
 import org.mule.runtime.oauth.api.state.DefaultResourceOwnerOAuthContext;
-import org.mule.service.oauth.internal.DefaultClientCredentialsOAuthDancer;
+import org.mule.service.oauth.internal.clientcredentials.DefaultClientCredentialsOAuthDancer;
 
 import java.util.Map;
 

--- a/src/main/java/org/mule/service/oauth/internal/clientcredentials/AbstractClientCredentialsOAuthDancer.java
+++ b/src/main/java/org/mule/service/oauth/internal/clientcredentials/AbstractClientCredentialsOAuthDancer.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.service.oauth.internal;
+package org.mule.service.oauth.internal.clientcredentials;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonMap;
@@ -63,7 +63,7 @@ import java.util.function.Function;
  *
  * @since 1.0
  */
-public abstract class AbstractOAuthDancer implements Startable, Stoppable {
+public abstract class AbstractClientCredentialsOAuthDancer implements Startable, Stoppable {
 
   private static final int TOKEN_REQUEST_TIMEOUT_MILLIS = 60000;
 
@@ -85,13 +85,13 @@ public abstract class AbstractOAuthDancer implements Startable, Stoppable {
   private final HttpClient httpClient;
   private final MuleExpressionLanguage expressionEvaluator;
 
-  protected AbstractOAuthDancer(String clientId, String clientSecret, String tokenUrl, Charset encoding, String scopes,
-                                ClientCredentialsLocation clientCredentialsLocation, String responseAccessTokenExpr,
-                                String responseRefreshTokenExpr, String responseExpiresInExpr,
-                                Map<String, String> customParametersExtractorsExprs,
-                                Function<String, String> resourceOwnerIdTransformer, LockFactory lockProvider,
-                                Map<String, DefaultResourceOwnerOAuthContext> tokensStore, HttpClient httpClient,
-                                MuleExpressionLanguage expressionEvaluator) {
+  protected AbstractClientCredentialsOAuthDancer(String clientId, String clientSecret, String tokenUrl, Charset encoding, String scopes,
+                                                 ClientCredentialsLocation clientCredentialsLocation, String responseAccessTokenExpr,
+                                                 String responseRefreshTokenExpr, String responseExpiresInExpr,
+                                                 Map<String, String> customParametersExtractorsExprs,
+                                                 Function<String, String> resourceOwnerIdTransformer, LockFactory lockProvider,
+                                                 Map<String, DefaultResourceOwnerOAuthContext> tokensStore, HttpClient httpClient,
+                                                 MuleExpressionLanguage expressionEvaluator) {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.tokenUrl = tokenUrl;
@@ -160,7 +160,7 @@ public abstract class AbstractOAuthDancer implements Startable, Stoppable {
         .responseTimeout(TOKEN_REQUEST_TIMEOUT_MILLIS)
         .build())
         .exceptionally(t -> {
-          return withContextClassLoader(AbstractOAuthDancer.class.getClassLoader(), () -> {
+          return withContextClassLoader(AbstractClientCredentialsOAuthDancer.class.getClassLoader(), () -> {
             if (t instanceof IOException) {
               throw new CompletionException(new TokenUrlResponseException(tokenUrl, (IOException) t));
             } else {
@@ -169,7 +169,7 @@ public abstract class AbstractOAuthDancer implements Startable, Stoppable {
           });
         })
         .thenApply(response -> {
-          return withContextClassLoader(AbstractOAuthDancer.class.getClassLoader(), () -> {
+          return withContextClassLoader(AbstractClientCredentialsOAuthDancer.class.getClassLoader(), () -> {
             String contentType = response.getHeaderValue(CONTENT_TYPE);
             MediaType responseContentType = contentType != null ? parse(contentType) : ANY;
 

--- a/src/main/java/org/mule/service/oauth/internal/clientcredentials/DefaultClientCredentialsOAuthDancer.java
+++ b/src/main/java/org/mule/service/oauth/internal/clientcredentials/DefaultClientCredentialsOAuthDancer.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.service.oauth.internal;
+package org.mule.service.oauth.internal.clientcredentials;
 
 import static java.lang.Thread.currentThread;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -47,7 +47,7 @@ import java.util.function.Function;
  *
  * @since 1.0
  */
-public class DefaultClientCredentialsOAuthDancer extends AbstractOAuthDancer implements Startable, ClientCredentialsOAuthDancer {
+public class DefaultClientCredentialsOAuthDancer extends AbstractClientCredentialsOAuthDancer implements Startable, ClientCredentialsOAuthDancer {
 
   private static final Logger LOGGER = getLogger(DefaultClientCredentialsOAuthDancer.class);
 


### PR DESCRIPTION
This code introduces a new Service to delegate a part of the OAuth2 Authorization Code grant flow to a new REST Service. For this, we introduce two new entities:

* **AuthorizationCodeOAuthDancerDelegate**: generated by the builder and in charge to decide which one to use, based on the `resourceOwnerId`.
* **MuleSoftAuthorizationCodeOAuthDancer**: responsible for calling the `/token` endpoint to either generate a new token or refresh it.

In addition, we moved some files in different packages and created an **AbstractAuthorizationCodeOAuthDancer** abstract class to encapsulate common logic.

## What the MuleSoftAuthorizationCodeOAuthDancer does

In a nutshell:

* When the `accessToken()` method is called, it tries to get the token from the context. If it doesn't exists, it makes a call to the new service retrieve a token (first time scenario). 
    * Default strategy simply fails because you need to make a call to `/authorize` first (it's already done by FD in the new scenario).
* When the `refreshToken()` method is called, it tries to retrieve a token from the new service by sending: 
    * A Core Services access token to authn & authz the request. **TODO: add a role to the token.**
    * An access token, if exists, to potentially cache the call (i.e. two mule apps making the same call should get the same token).
* Notice that for this to work we need the following information in the XML:
    * A `Client ID` and a `Client Secret` (potentially autogenerated but dummy).
    * (for now) A `Resource owner ID` with a specific prefix. This might change in the near future (we can use ClientID instead).
    * A `Token URL`, pointing to the proper service.


## TODO:

* There are some methods in the `AuthorizationCodeOAuthDancer` interface that we might need to remove or find a way to detect which dancer to use (somehow). Potentially removed by using ClientID and ClientSecret.

```
public interface AuthorizationCodeOAuthDancer {
    ...
    void handleLocalAuthorizationRequest(HttpRequest request, HttpResponseReadyCallback responseCallback);
    void addListener(AuthorizationCodeListener listener);
    void removeListener(AuthorizationCodeListener listener);
}
```

* How should we identify which dancer to use. Today we use a prefix in the `resourceOwnerId` XML property. But we might want to change it to the `clientId`.
* We still have to retrieve a CS access token using CS Client ID and secret. *How can we get CS API?*
* Minor tweaks and refactors.